### PR TITLE
Guardar direccion mapa

### DIFF
--- a/src/app/comercio/administracion/formularios/form-addresses/form-address/form-address.ctrl.js
+++ b/src/app/comercio/administracion/formularios/form-addresses/form-address/form-address.ctrl.js
@@ -19,7 +19,6 @@
     $scope.longitudValida = false;
 
     $rootScope.$on('guardarDireccion', function(event, args) {
-      console.log("save escuchado por form address");
       $rootScope.guardarDireccion($scope.address);
     });
     //Muestra un alert simple, puede cambiarse para levantar

--- a/src/app/comercio/administracion/formularios/form-addresses/form-address/form-address.ctrl.js
+++ b/src/app/comercio/administracion/formularios/form-addresses/form-address/form-address.ctrl.js
@@ -6,7 +6,7 @@
 
   /*
    *  Formulario para direccion */
-  function FormAddressController($log, $scope, $mdDialog) {
+  function FormAddressController($log, $scope, $mdDialog, $rootScope) {
 
     $log.debug("FormAddressController", $scope.address);
 
@@ -18,7 +18,10 @@
     $scope.latitudValida = false;
     $scope.longitudValida = false;
 
-    
+    $rootScope.$on('guardarDireccion', function(event, args) {
+      console.log("save escuchado por form address");
+      $rootScope.guardarDireccion($scope.address);
+    });
     //Muestra un alert simple, puede cambiarse para levantar
     //mensaje mas complejo y amigable definiendo una pagina HTML.
     function showAlert(ev, mensaje) {

--- a/src/app/comercio/administracion/formularios/map.controller.js
+++ b/src/app/comercio/administracion/formularios/map.controller.js
@@ -174,7 +174,7 @@ angular.module('chasqui').controller('MapGeocoderController', ['$scope', '$rootS
       return (!$scope.latitudValida|| !$scope.longitudValida||!$scope.calleValida || !$scope.localidadValida || !$scope.alturaValida || !$scope.aliasValido || $rootScope.isDisabled);
     };
 
-    $scope.formIsValidForSave = function() {
+    $scope.formIsValidForSave = function() {   
       return formValidoParaGuardar();
     };
 

--- a/src/app/comercio/administracion/formularios/webmap.controller.js
+++ b/src/app/comercio/administracion/formularios/webmap.controller.js
@@ -15,7 +15,7 @@ angular.module('chasqui').controller('MapWebController', ['MapDraw','MapUI', 'Ma
     $rootScope.auto_localizar = "Marcar";
     $rootScope.global_marker;
     $rootScope.vmGlobal;
-    $rootScope.nameMarker;
+    $rootScope.nameMarker;    
     var posicionMapaPredeterminado = [-34.7739, -58.5520];
 
     var blueIcon = L.icon({
@@ -172,7 +172,7 @@ angular.module('chasqui').controller('MapWebController', ['MapDraw','MapUI', 'Ma
     };
 
     $scope.formIsValidForSave = function() {
-      return formValidoParaGuardar();
+       return formValidoParaGuardar();
     };
 
     $scope.isSearching = function() {
@@ -240,6 +240,7 @@ angular.module('chasqui').controller('MapWebController', ['MapDraw','MapUI', 'Ma
     $scope.$on('posicionValida', function(event, args) {
        $log.debug(args);
        loadGlobalCoordinatesInProfile(args.lat, args.lng);
+       $rootScope.$emit('guardarDireccion', null );
     });
 
     $rootScope.$on('cambioANuevaDireccion', function(event, args) {

--- a/src/app/comercio/administracion/perfil.controller.js
+++ b/src/app/comercio/administracion/perfil.controller.js
@@ -282,8 +282,16 @@
     ///////////////////////////////////////////
     /////////// Addresses functions ///////////
     ///////////////////////////////////////////
-
-
+    $rootScope.guardarDireccion = function(address) {
+        $log.debug("Guardar Domicilio , nuevo? ", address.isNew);
+        if (address.isNew) {
+            callNuevaDireccion(filterFields(address, ["isNew"]));
+        } else {
+            callUpdateDireccion(filterFields(address, ["isNew"]));
+        }
+        $scope.$emit('cambioANuevaDireccion');
+    }
+    
     $scope.save = function(address) {
         $log.debug("Guardar Domicilio , nuevo? ", address.isNew);
         if (address.isNew) {


### PR DESCRIPTION
Se aplicó "guardar dirección" directamente a la acción de confirmar que la posicion en el mapa es correcta.